### PR TITLE
Replace registry with static threadpool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 parking_lot = "0.12.3"
 async-task = "4.7.1"
 crossbeam-utils = "0.8.21"
-crossbeam-deque = "0.8.6"
+concurrent-queue = "2.5.0"
 
 [dev-dependencies]
 winit = "0.30.7"
+criterion = "0.5"
+
+[[bench]]
+name = "bevy"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 parking_lot = "0.12.3"
 async-task = "4.7.1"
 crossbeam-utils = "0.8.21"
-concurrent-queue = "2.5.0"
+crossbeam-queue = "0.3.12"
 
 [dev-dependencies]
 winit = "0.30.7"

--- a/src/latch.rs
+++ b/src/latch.rs
@@ -154,6 +154,15 @@ impl WakeLatch {
         }
     }
 
+    #[inline]
+    pub const fn new_raw(thread_index: usize, thread_pool: &'static ThreadPool) -> WakeLatch {
+        WakeLatch {
+            atomic_latch: AtomicLatch::new(),
+            thread_pool,
+            thread_index,
+        }
+    }
+
     /// Resets the latch back to closed.
     #[inline]
     pub fn reset(&self) {
@@ -193,7 +202,7 @@ pub struct LockLatch {
 impl LockLatch {
     /// Creates a new closed latch.
     #[inline]
-    pub fn new() -> LockLatch {
+    pub const fn new() -> LockLatch {
         LockLatch {
             mutex: Mutex::new(false),
             cond: Condvar::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,6 @@ mod util;
 pub mod prelude {
     pub use crate::{
         scope::Scope,
-        thread_pool::{ThreadPool, ThreadPoolConfig},
+        thread_pool::{ThreadPool, WorkerThread},
     };
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -13,9 +13,9 @@ use crate::{
 // Scope
 
 /// A scope which can spawn a number of non-static jobs and async tasks. See
-/// [`Registry::scope`] for more information.
+/// [`ThreadPool::scope`] for more information.
 pub struct Scope<'scope> {
-    /// The registry the scope operates on.
+    /// The thread pool the scope is for.
     thread_pool: &'static ThreadPool,
     /// A counting latch that opens when all jobs spawned in this scope are complete.
     job_completed_latch: CountLatch,
@@ -30,7 +30,7 @@ pub struct Scope<'scope> {
 
 impl<'scope> Scope<'scope> {
     /// Creates a new scope owned by the given worker thread. For a safe
-    /// equivalent, use [`Registry::scope`].
+    /// equivalent, use [`ThreadPool::scope`].
     ///
     /// Two important lifetimes effect scope: the external lifetime of the scope
     /// object itself (which we will call `'ext`) and the internal lifetime
@@ -69,7 +69,7 @@ impl<'scope> Scope<'scope> {
     ///
     /// # See also
     ///
-    /// The [`Registry::scope`] function has more extensive documentation about
+    /// The [`ThreadPool::scope`] function has more extensive documentation about
     /// task spawning.
     pub fn spawn<F>(&self, f: F)
     where

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -40,7 +40,7 @@ impl<'scope> Scope<'scope> {
     ///
     /// The caller must ensure that the scope is completed with a call to
     /// [`Scope::complete`], passing in a reference the same owning worker
-    /// thread both times. 
+    /// thread both times.
     ///
     /// If the scope is not completed, jobs spawned onto this scope may outlive
     /// the data they close over.
@@ -173,22 +173,19 @@ impl<'scope> Scope<'scope> {
 
             // Now we turn the runnable into a job-ref that we can send to a
             // worker.
-            
+
             // SAFETY: We provide a pointer to a non-null runnable, and we turn
             // it back into a non-null runnable. The runnable will remain valid
             // until the task is run.
             let job_ref = unsafe {
-                JobRef::new_raw(
-                    runnable.into_raw().as_ptr(),
-                    |this| {
-                        let this = NonNull::new_unchecked(this as *mut ());
-                        let runnable = Runnable::<()>::from_raw(this);
-                        // Poll the task.
-                        runnable.run();
-                    }
-                )
+                JobRef::new_raw(runnable.into_raw().as_ptr(), |this| {
+                    let this = NonNull::new_unchecked(this as *mut ());
+                    let runnable = Runnable::<()>::from_raw(this);
+                    // Poll the task.
+                    runnable.run();
+                })
             };
-            
+
             // Send this job off to be executed. When this schedule function is
             // called on a worker thread this re-schedules it onto the worker's
             // local queue, which will generally cause tasks to stick to the
@@ -220,9 +217,10 @@ impl<'scope> Scope<'scope> {
     /// [`Scope::spawn_future`]. See the docs on that function for more
     /// information.
     pub fn spawn_async<Fn, Fut, T>(&self, f: Fn) -> Task<T>
-    where Fn: FnOnce(&Scope<'scope>) -> Fut + Send + 'static,
-          Fut: Future<Output = T> + Send + 'static,
-          T: Send + 'static
+    where
+        Fn: FnOnce(&Scope<'scope>) -> Fut + Send + 'static,
+        Fut: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
     {
         // Wrap the function into a future using an async block.
         let scope_ptr = ScopePtr(self);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,11 @@
+use std::{
+    cell::{Cell, UnsafeCell},
+    mem::{needs_drop, MaybeUninit},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
 // -----------------------------------------------------------------------------
-// Utilities
+// Call on drop guard
 
 // A guard that calls the specified closure when it is dropped. This is used
 // internally to run logic when a `Future` is canceled or completed.
@@ -8,5 +14,146 @@ pub struct CallOnDrop<F: FnMut()>(pub F);
 impl<F: FnMut()> Drop for CallOnDrop<F> {
     fn drop(&mut self) {
         (self.0)();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Slot
+
+/// A slot is a simple atomic store. Like `Option`, slots are either empty or
+/// contain a single value. But unlike `Option`, slots are opaque: the only way
+/// to tell if a slot contains a value is to remove it.
+///
+/// Slot supports only two operations:
+/// + `put` inserts a value into an empty slot (and fails when occupied).
+/// + `take` removes a value from an occupied slot (and files when empty).
+///
+/// Both these operations are lock-free. The failing path costs only an atomic
+/// read. The success path costs an atomic read and three quick writes (which
+/// should only ever cause one cache miss on other threads).
+///
+/// Neither `put` nor `take` will spin.
+pub struct Slot<T> {
+    slot: UnsafeCell<MaybeUninit<T>>,
+    flag: AtomicUsize,
+}
+
+// A flag state indicating the slot is empty. This allows `put` but not `take`.
+const NONE: usize = 0;
+
+// A flag state indicating either a `put` or a `take` is in progress.
+const LOCK: usize = 1;
+
+// A flag state indicating the slot is occupied. This allows `take` but not `put`.
+const SOME: usize = 2;
+
+impl<T> Slot<T> {
+    /// Creates an empty slot.
+    pub const fn empty() -> Slot<T> {
+        Slot {
+            slot: UnsafeCell::new(MaybeUninit::uninit()),
+            flag: AtomicUsize::new(NONE),
+        }
+    }
+
+    /// Tries to put a new value in the slot. If the slot is already occupied
+    /// the new value is returned. Returning `None` indicates a successful insertion.
+    pub fn put(&self, value: T) -> Option<T> {
+        match self
+            .flag
+            .compare_exchange(NONE, LOCK, Ordering::Acquire, Ordering::Relaxed)
+        {
+            Err(_) => Some(value),
+            Ok(_) => {
+                unsafe {
+                    let slot = &mut *(self.slot.get());
+                    slot.write(value);
+                };
+                self.flag.store(SOME, Ordering::Release);
+                None
+            }
+        }
+    }
+
+    /// Takes the value from the slot. Returns none if the slot is empty.
+    pub fn take(&self) -> Option<T> {
+        match self
+            .flag
+            .compare_exchange(SOME, LOCK, Ordering::Acquire, Ordering::Relaxed)
+        {
+            Err(_) => None,
+            Ok(_) => {
+                let value;
+                unsafe {
+                    let slot = &mut *(self.slot.get());
+                    value = slot.assume_init_read();
+                };
+                self.flag.store(NONE, Ordering::Release);
+                Some(value)
+            }
+        }
+    }
+}
+
+impl<T> Drop for Slot<T> {
+    fn drop(&mut self) {
+        // If `T` dosn't need to be dropped then neither does `Slot`.
+        if needs_drop::<T>() {
+            let Slot { flag, slot } = self;
+            // SAFETY: The flag value is always set to either `NONE` or `SOME`.
+            // Slots are never dropped when the flag is `LOCK`. If the flag is
+            // `NONE` then the slot is empty and nothing needs to be dropped.
+            // If it is `SOME` then the value is initalized and we must
+            // manually drop it.
+            unsafe {
+                if *flag.get_mut() == SOME {
+                    slot.get_mut().as_mut_ptr().drop_in_place();
+                }
+            }
+        }
+    }
+}
+
+/// SAFETY: A `Slot<T>` contains `T` so is `Send` iff `T` is send.
+unsafe impl<T> Send for Slot<T> where T: Send {}
+
+/// SAFETY: A `&Slot<T>` lets you get a `T` via `Slot::take()`. If `Slot<T>` is
+/// `Sync` this could cause `T` to be sent to another thread. So `Slot<T>` is
+/// `Sync` iff `T` is `Send`.
+unsafe impl<T> Sync for Slot<T> where T: Send {}
+
+// -----------------------------------------------------------------------------
+// Xorshift fast prng (taken from rayon)
+
+/// [xorshift*] is a fast pseudorandom number generator which will
+/// even tolerate weak seeding, as long as it's not zero.
+///
+/// [xorshift*]: https://en.wikipedia.org/wiki/Xorshift#xorshift*
+pub struct XorShift64Star {
+    state: Cell<u64>,
+}
+
+impl XorShift64Star {
+    /// Initializes the prng with a seed. Provided seed must be nonzero.
+    pub fn new(seed: u64) -> Self {
+        XorShift64Star {
+            state: Cell::new(seed),
+        }
+    }
+
+    /// Returns a pseudorandom number.
+    pub fn next(&self) -> u64 {
+        let mut x = self.state.get();
+        debug_assert_ne!(x, 0);
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.state.set(x);
+        x.wrapping_mul(0x2545_f491_4f6c_dd1d)
+    }
+
+    /// Return a pseudorandom number from `0..n`.
+    pub fn next_usize(&self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
     }
 }


### PR DESCRIPTION
Part of implementing https://github.com/NthTensor/Forte/issues/1 and how I want to approach bench-marking for https://github.com/NthTensor/Forte/issues/2.

This reworks the api around `&'static Threadpool` instead of `Arc<Registry>`. Thread pools are now static objects which can create or remove workers dynamically during runtime. Jobs can still be added to a thread with zero workers; they simply wait to be executed until more workers are added. On this whole this greatly simplifies state tracking, eliminates a class of mostly useless atomic writes, and makes the library simpler to use.