### PR TITLE
Add `loom` integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: cargo run -p ci -- doc
         env:
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "--cfg loom -C debuginfo=0"
+          RUSTFLAGS: "-C debuginfo=0"
 
   test-loom:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,27 @@ jobs:
         run: cargo run -p ci -- doc
         env:
           CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "--cfg loom -C debuginfo=0"
+
+  test-loom:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-check-doc-${{ hashFiles('**/Cargo.toml') }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build and check doc
+        run: cargo run -p ci -- loom
+        env:
+          CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
 
   typos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Build & run tests
         run: cargo run -p ci -- compile
@@ -41,7 +41,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-lints-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -61,7 +61,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-check-doc-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-lints-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Build and check doc
         run: cargo run -p ci -- doc
@@ -82,7 +82,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-check-doc-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-test-loom-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Build and check doc
         run: cargo run -p ci -- loom

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ members = [
 ]
 
 [dependencies]
-parking_lot = "0.12.3"
 async-task = "4.7.1"
 crossbeam-utils = "0.8.21"
 crossbeam-queue = "0.3.12"
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
 
 [lints.clippy]
 doc_markdown = "warn"
@@ -40,3 +41,13 @@ alloc_instead_of_core = "warn"
 missing_docs = "warn"
 unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
+
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
+# Add loom as a dependency for tests
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"
+
+[[test]]
+name = "integration"
+path = "tests/tests.rs"

--- a/ci/src/ci.rs
+++ b/ci/src/ci.rs
@@ -76,6 +76,9 @@ impl CI {
                 cmds.append(&mut commands::CompileCheckCommand::default().prepare(sh, flags));
                 cmds.append(&mut commands::DocCheckCommand::default().prepare(sh, flags));
                 cmds.append(&mut commands::DocTestCommand::default().prepare(sh, flags));
+                cmds.append(&mut commands::LoomCheckCommand::default().prepare(sh, flags));
+                cmds.append(&mut commands::LoomClippyCommand::default().prepare(sh, flags));
+                cmds.append(&mut commands::LoomTestCommand::default().prepare(sh, flags));
                 cmds
             }
         }
@@ -97,6 +100,11 @@ enum Commands {
     Lints(commands::LintsCommand),
     Clippy(commands::ClippyCommand),
     Format(commands::FormatCommand),
+    // Loom commands
+    Loom(commands::LoomCommand),
+    LoomCheck(commands::LoomCheckCommand),
+    LoomClippy(commands::LoomClippyCommand),
+    LoomTest(commands::LoomTestCommand),
 }
 
 impl Prepare for Commands {
@@ -113,6 +121,11 @@ impl Prepare for Commands {
             Commands::Lints(subcommand) => subcommand.prepare(sh, flags),
             Commands::Clippy(subcommand) => subcommand.prepare(sh, flags),
             Commands::Format(subcommand) => subcommand.prepare(sh, flags),
+            // Loom commands
+            Commands::Loom(subcommand) => subcommand.prepare(sh, flags),
+            Commands::LoomCheck(subcommand) => subcommand.prepare(sh, flags),
+            Commands::LoomClippy(subcommand) => subcommand.prepare(sh, flags),
+            Commands::LoomTest(subcommand) => subcommand.prepare(sh, flags),
         }
     }
 }

--- a/ci/src/commands/loom.rs
+++ b/ci/src/commands/loom.rs
@@ -1,0 +1,20 @@
+use crate::{
+    commands::{LoomCheckCommand, LoomClippyCommand, LoomTestCommand},
+    Flag, Prepare, PreparedCommand,
+};
+use argh::FromArgs;
+
+/// Alias for running the `loom-check`, `loom-clippy` and `loom-test` subcommands.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "loom")]
+pub struct LoomCommand {}
+
+impl Prepare for LoomCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let mut commands = vec![];
+        commands.append(&mut LoomCheckCommand::default().prepare(sh, flags));
+        commands.append(&mut LoomClippyCommand::default().prepare(sh, flags));
+        commands.append(&mut LoomTestCommand::default().prepare(sh, flags));
+        commands
+    }
+}

--- a/ci/src/commands/loom_check.rs
+++ b/ci/src/commands/loom_check.rs
@@ -1,0 +1,19 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Checks that the loom test suite compiles.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "loom-check")]
+pub struct LoomCheckCommand {}
+
+impl Prepare for LoomCheckCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let command = PreparedCommand::new::<Self>(
+            cmd!(sh, "cargo check --test loom"),
+            "Please fix compiler errors in output above.",
+        )
+        .with_env_var("RUSTFLAGS", "--cfg loom");
+        vec![command]
+    }
+}

--- a/ci/src/commands/loom_clippy.rs
+++ b/ci/src/commands/loom_clippy.rs
@@ -1,0 +1,19 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Checks for clippy warnings and errors in the loom test suite.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "loom-clippy")]
+pub struct LoomClippyCommand {}
+
+impl Prepare for LoomClippyCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let command = PreparedCommand::new::<Self>(
+            cmd!(sh, "cargo clippy --test loom -- -Dwarnings"),
+            "Please fix clippy errors in output above.",
+        )
+        .with_env_var("RUSTFLAGS", "--cfg loom");
+        vec![command]
+    }
+}

--- a/ci/src/commands/loom_test.rs
+++ b/ci/src/commands/loom_test.rs
@@ -14,7 +14,7 @@ impl Prepare for LoomTestCommand {
             "Please fix compiler errors in output above.",
         )
         .with_env_var("RUSTFLAGS", "--cfg loom")
-        .with_env_var("LOOM_MAX_PREEMPTIONS", "5");
+        .with_env_var("LOOM_MAX_PREEMPTIONS", "3");
         vec![command]
     }
 }

--- a/ci/src/commands/loom_test.rs
+++ b/ci/src/commands/loom_test.rs
@@ -1,0 +1,20 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Runs the loom concurrency test suite.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "loom-test")]
+pub struct LoomTestCommand {}
+
+impl Prepare for LoomTestCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let command = PreparedCommand::new::<Self>(
+            cmd!(sh, "cargo test --test loom --release"),
+            "Please fix compiler errors in output above.",
+        )
+        .with_env_var("RUSTFLAGS", "--cfg loom")
+        .with_env_var("LOOM_MAX_PREEMPTIONS", "5");
+        vec![command]
+    }
+}

--- a/ci/src/commands/mod.rs
+++ b/ci/src/commands/mod.rs
@@ -22,3 +22,14 @@ mod lints;
 pub use clippy::*;
 pub use format::*;
 pub use lints::*;
+
+// Loom test suite commands
+mod loom;
+mod loom_check;
+mod loom_clippy;
+mod loom_test;
+
+pub use loom::*;
+pub use loom_check::*;
+pub use loom_clippy::*;
+pub use loom_test::*;

--- a/src/job.rs
+++ b/src/job.rs
@@ -174,7 +174,8 @@ where
         // SAFETY: The caller ensures this points to a valid `StackJob`.
         let this = unsafe { &*(this.cast::<Self>()) };
         let job = this.job.get_mut();
-        // SAFETY: TODO
+        // SAFETY: This is called at most once and the job is otherwise never
+        // dereferenced so there can be no other mutable references.
         let job_func = unsafe { job.deref().take().unwrap() };
         // Run the job.
         job_func();

--- a/src/job.rs
+++ b/src/job.rs
@@ -13,7 +13,8 @@
 //! (c) Each job reference is executed exactly once.
 
 use alloc::boxed::Box;
-use core::cell::UnsafeCell;
+
+use crate::primitives::*;
 
 // -----------------------------------------------------------------------------
 // Job
@@ -172,11 +173,11 @@ where
     unsafe fn execute(this: *const ()) {
         // SAFETY: The caller ensures this points to a valid `StackJob`.
         let this = unsafe { &*(this.cast::<Self>()) };
-        // SAFETY: This should be called exactly once for each stack-job, so
-        // there can be no other mutable references to the inner value of the
-        // unsafe cell.
-        let job = unsafe { (*this.job.get()).take().unwrap() };
-        job();
+        let job = this.job.get_mut();
+        // SAFETY: TODO
+        let job_func = unsafe { job.deref().take().unwrap() };
+        // Run the job.
+        job_func();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,8 @@ mod primitives {
     pub use std::thread::available_parallelism;
     pub use std::thread::spawn as spawn_thread;
 
+    pub use crossbeam_queue::SegQueue as Queue;
+
     pub struct UnsafeCell<T> {
         data: core::cell::UnsafeCell<T>,
     }
@@ -148,4 +150,28 @@ mod primitives {
     pub use loom::thread::spawn as spawn_thread;
 
     pub use std::thread::available_parallelism;
+
+    use alloc::vec::Vec;
+
+    pub struct Queue<T> {
+        inner: Mutex<Vec<T>>,
+    }
+
+    impl<T> Queue<T> {
+        pub fn new() -> Queue<T> {
+            Queue {
+                inner: Mutex::new(Vec::new()),
+            }
+        }
+
+        pub fn push(&self, val: T) {
+            let mut vec = self.inner.lock().unwrap();
+            vec.push(val);
+        }
+
+        pub fn pop(&self) -> Option<T> {
+            let mut vec = self.inner.lock().unwrap();
+            vec.pop()
+        }
+    }
 }

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -1,0 +1,3 @@
+//! General integration tests
+
+#![cfg(not(loom))]

--- a/tests/loom.rs
+++ b/tests/loom.rs
@@ -1,0 +1,158 @@
+//! Tests using the `loom` testing framework.
+
+#![cfg(loom)]
+
+use core::hint::black_box;
+
+use loom::model::Builder;
+use tracing::{info, Level};
+use tracing_subscriber::fmt::Subscriber;
+
+use forte::prelude::*;
+
+fn model<F>(f: F)
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    let subscriber = Subscriber::builder()
+        .with_max_level(Level::DEBUG)
+        .with_test_writer()
+        .without_time()
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        let mut model = Builder::new();
+        model.log = true;
+        model.check(f);
+    });
+}
+
+/// Provides access to a thread pool which can be treated as static for the
+/// purposes of testing.
+fn with_thread_pool<F>(f: F)
+where
+    F: Fn(&'static ThreadPool),
+{
+    info!("### SETTING UP TEST");
+
+    // Create a new thread pool.
+    let thread_pool = Box::new(ThreadPool::new());
+    let ptr = Box::into_raw(thread_pool);
+
+    // SAFETY: We want to create have a reference to the thread pool which can
+    // be treated as `'static` by the callback `f`. We will assume that `f` has
+    // no side-effects except for those created by calls to the thread pool.
+    // This problem comes down to ensuring that `thread_pool` lives for the
+    // duration of `f` and also outlives anything spawned onto the pool by `f`.
+    //
+    // The first condition is easily satisfied: the thread pool is not dropped
+    // until the end of the scope. For the latter condition, the call to
+    // `wait_until_inactive()` blocks the thread until all work spawned onto the
+    // pool completes, and `resize_to(0)` blocks until all of the pool's threads
+    // terminate.
+    //
+    // For all intents and purposes, so long as `f` has no other side-effects,
+    // `thread_pool` can be treated as if it has a `'static` lifetime within
+    // `f`.
+    unsafe {
+        let thread_pool = &*ptr;
+        info!("### POPULATING POOL");
+        thread_pool.populate();
+        info!("### STARTING TEST");
+        f(thread_pool);
+        info!("### FINISHING TEST");
+        thread_pool.wait_until_inactive();
+        info!("### SHUTTING DOWN POOL");
+        thread_pool.resize_to(0);
+    };
+
+    // SAFETY: This was created by `Box::into_raw`.
+    let thread_pool = unsafe { Box::from_raw(&mut *ptr) };
+    drop(thread_pool);
+
+    info!("### TEST COMPLETE");
+}
+
+// Test of the `with_thread_pool` helper function. This spins up a thread pool
+// with a single thread, then spins it back down.
+#[test]
+pub fn resize_one() {
+    model(|| {
+        with_thread_pool(|_| {});
+    });
+}
+
+// Tests increasing the size of the pool
+#[test]
+pub fn resize_grow() {
+    model(|| {
+        with_thread_pool(|threads| {
+            threads.grow(1);
+        });
+    });
+}
+
+// Tests shrinking the size of the pool
+#[test]
+pub fn resize_shrink() {
+    model(|| {
+        with_thread_pool(|threads| {
+            threads.shrink(1);
+        });
+    });
+}
+
+#[test]
+pub fn join() {
+    model(|| {
+        with_thread_pool(|threads| {
+            threads.join(|| black_box(threads), || black_box(threads));
+        });
+    });
+}
+
+#[test]
+pub fn block_on() {
+    model(|| {
+        with_thread_pool(|threads| {
+            threads.block_on(async {
+                black_box(threads);
+            });
+        });
+    });
+}
+
+#[test]
+pub fn spawn_closure() {
+    model(|| {
+        with_thread_pool(|threads| {
+            threads.spawn(move || {
+                black_box(threads);
+            });
+        });
+    });
+}
+
+#[test]
+pub fn spawn_future() {
+    model(|| {
+        with_thread_pool(|threads| {
+            let task = threads.spawn_future(async move {
+                black_box(threads);
+            });
+            task.detach();
+        });
+    });
+}
+
+#[test]
+pub fn spawn_and_block() {
+    model(|| {
+        with_thread_pool(|threads| {
+            let task = threads.spawn_future(async move {
+                black_box(threads);
+            });
+            threads.block_on(task);
+        });
+    });
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,4 @@
+//! Entrypoint for all of Forte's tests
+
+mod general;
+mod loom;


### PR DESCRIPTION
Adds integration testing for deadlocks and data-races with `loom`. Also fixes several deadlocks identified while adding the tests. Switches from `parking_lot` back to the `std` locks, we can consider switching back when we have benchmarks.