### PR TITLE
Add CI tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  merge_group:
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build & run tests
+        run: cargo run -p ci -- compile
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+  lints:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Lints
+        run: cargo run -p ci -- lints
+
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-check-doc-${{ hashFiles('**/Cargo.toml') }}
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build and check doc
+        run: cargo run -p ci -- doc
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0"
+
+  typos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for typos
+        uses: crate-ci/typos@v1.28.4
+      - name: Typos info
+        if: failure()
+        run: |
+          echo 'To fix typos, please run `typos -w`'
+          echo 'To check for a diff, run `typos`'
+          echo 'You can find typos here: https://crates.io/crates/typos'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,6 @@ crossbeam-queue = "0.3.12"
 winit = "0.30.7"
 criterion = "0.5"
 
-[[bench]]
-name = "bevy"
-harness = false
-
 [lints.clippy]
 doc_markdown = "warn"
 manual_let_else = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ license = "MIT OR Apache-2.0"
 description = "A low-overhead thread-pool with support for non-static async closures"
 repository = "https://github.com/NthTensor/Forte"
 
+[workspace]
+resolver = "2"
+members = [
+  "ci"
+]
+
 [dependencies]
 parking_lot = "0.12.3"
 async-task = "4.7.1"
@@ -19,3 +25,26 @@ criterion = "0.5"
 [[bench]]
 name = "bevy"
 harness = false
+
+[lints.clippy]
+doc_markdown = "warn"
+manual_let_else = "warn"
+match_same_arms = "warn"
+redundant_closure_for_method_calls = "warn"
+redundant_else = "warn"
+semicolon_if_nothing_returned = "warn"
+undocumented_unsafe_blocks = "warn"
+unwrap_or_default = "warn"
+
+ptr_as_ptr = "warn"
+ptr_cast_constness = "warn"
+ref_as_ptr = "warn"
+
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+alloc_instead_of_core = "warn"
+
+[lints.rust]
+missing_docs = "warn"
+unsafe_op_in_unsafe_fn = "warn"
+unused_qualifications = "warn"

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "ci"
+edition = "2021"
+description = "Tool that enables running CI checks locally."
+publish = false
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+argh = "0.1"
+xshell = "0.2"
+bitflags = "2.3"
+
+[lints.clippy]
+doc_markdown = "warn"
+manual_let_else = "warn"
+match_same_arms = "warn"
+redundant_closure_for_method_calls = "warn"
+redundant_else = "warn"
+semicolon_if_nothing_returned = "warn"
+undocumented_unsafe_blocks = "warn"
+unwrap_or_default = "warn"
+
+ptr_as_ptr = "warn"
+ptr_cast_constness = "warn"
+ref_as_ptr = "warn"
+
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+alloc_instead_of_core = "warn"
+
+[lints.rust]
+missing_docs = "warn"
+unsafe_code = "deny"
+unsafe_op_in_unsafe_fn = "warn"
+unused_qualifications = "warn"

--- a/ci/src/ci.rs
+++ b/ci/src/ci.rs
@@ -70,7 +70,12 @@ impl CI {
             None => {
                 // Note that we are running the subcommands directly rather than using any aliases
                 let mut cmds = vec![];
+                cmds.append(&mut commands::FormatCommand::default().prepare(sh, flags));
+                cmds.append(&mut commands::ClippyCommand::default().prepare(sh, flags));
+                cmds.append(&mut commands::LintsCommand::default().prepare(sh, flags));
                 cmds.append(&mut commands::CompileCheckCommand::default().prepare(sh, flags));
+                cmds.append(&mut commands::DocCheckCommand::default().prepare(sh, flags));
+                cmds.append(&mut commands::DocTestCommand::default().prepare(sh, flags));
                 cmds
             }
         }

--- a/ci/src/ci.rs
+++ b/ci/src/ci.rs
@@ -1,0 +1,113 @@
+use crate::{
+    commands,
+    prepare::{Flag, Prepare, PreparedCommand},
+};
+use argh::FromArgs;
+
+/// The CI command line tool for Forte.
+#[derive(FromArgs)]
+pub struct CI {
+    #[argh(subcommand)]
+    command: Option<Commands>,
+
+    /// continue running commands even if one fails.
+    #[argh(switch)]
+    keep_going: bool,
+}
+
+impl CI {
+    /// Runs the specified commands or all commands if none are specified.
+    ///
+    /// When run locally, results may differ from actual CI runs triggered by `.github/workflows/ci.yml`.
+    /// This is usually related to differing toolchains and configuration.
+    pub fn run(self) {
+        let sh = xshell::Shell::new().unwrap();
+
+        let prepared_commands = self.prepare(&sh);
+
+        let mut failures = vec![];
+
+        for command in prepared_commands {
+            // If the CI test is to be executed in a subdirectory, we move there before running the command.
+            // This will automatically move back to the original directory once dropped.
+            let _subdir_hook = command.subdir.map(|path| sh.push_dir(path));
+
+            // Execute each command, checking if it returned an error.
+            if command.command.envs(command.env_vars).run().is_err() {
+                let name = command.name;
+                let message = command.failure_message;
+
+                if self.keep_going {
+                    // We use bullet points here because there can be more than one error.
+                    failures.push(format!("- {name}: {message}"));
+                } else {
+                    failures.push(format!("{name}: {message}"));
+                    break;
+                }
+            }
+        }
+
+        // Log errors at the very end.
+        if !failures.is_empty() {
+            let failures = failures.join("\n");
+
+            panic!(
+                "One or more CI commands failed:\n\
+                {failures}"
+            );
+        }
+    }
+
+    fn prepare<'a>(&self, sh: &'a xshell::Shell) -> Vec<PreparedCommand<'a>> {
+        let mut flags = Flag::empty();
+
+        if self.keep_going {
+            flags |= Flag::KEEP_GOING;
+        }
+
+        match &self.command {
+            Some(command) => command.prepare(sh, flags),
+            None => {
+                // Note that we are running the subcommands directly rather than using any aliases
+                let mut cmds = vec![];
+                cmds.append(&mut commands::CompileCheckCommand::default().prepare(sh, flags));
+                cmds
+            }
+        }
+    }
+}
+
+/// The subcommands that can be run by the CI script.
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum Commands {
+    // Compile commands
+    Compile(commands::CompileCommand),
+    CompileCheck(commands::CompileCheckCommand),
+    // Documentation commands
+    Doc(commands::DocCommand),
+    DocCheck(commands::DocCheckCommand),
+    DocTest(commands::DocTestCommand),
+    // Lint commands
+    Lints(commands::LintsCommand),
+    Clippy(commands::ClippyCommand),
+    Format(commands::FormatCommand),
+}
+
+impl Prepare for Commands {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
+        match self {
+            // Compile commands
+            Commands::Compile(subcommand) => subcommand.prepare(sh, flags),
+            Commands::CompileCheck(subcommand) => subcommand.prepare(sh, flags),
+            // Documentation commands
+            Commands::Doc(subcommand) => subcommand.prepare(sh, flags),
+            Commands::DocCheck(subcommand) => subcommand.prepare(sh, flags),
+            Commands::DocTest(subcommand) => subcommand.prepare(sh, flags),
+            // Lint commands
+            Commands::Lints(subcommand) => subcommand.prepare(sh, flags),
+            Commands::Clippy(subcommand) => subcommand.prepare(sh, flags),
+            Commands::Format(subcommand) => subcommand.prepare(sh, flags),
+        }
+    }
+}

--- a/ci/src/commands/clippy.rs
+++ b/ci/src/commands/clippy.rs
@@ -1,0 +1,20 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Check for clippy warnings and errors.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "clippy")]
+pub struct ClippyCommand {}
+
+impl Prepare for ClippyCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        vec![PreparedCommand::new::<Self>(
+            cmd!(
+                sh,
+                "cargo clippy --workspace --all-targets --all-features -- -Dwarnings"
+            ),
+            "Please fix clippy errors in output above.",
+        )]
+    }
+}

--- a/ci/src/commands/compile.rs
+++ b/ci/src/commands/compile.rs
@@ -1,0 +1,15 @@
+use crate::{commands::CompileCheckCommand, Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+
+/// Alias for running the `compile-fail`, `bench-check`, `example-check`, `compile-check`, and `test-check` subcommands.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "compile")]
+pub struct CompileCommand {}
+
+impl Prepare for CompileCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let mut commands = vec![];
+        commands.append(&mut CompileCheckCommand::default().prepare(sh, flags));
+        commands
+    }
+}

--- a/ci/src/commands/compile_check.rs
+++ b/ci/src/commands/compile_check.rs
@@ -1,0 +1,17 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Checks that the project compiles.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "compile-check")]
+pub struct CompileCheckCommand {}
+
+impl Prepare for CompileCheckCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        vec![PreparedCommand::new::<Self>(
+            cmd!(sh, "cargo check --workspace"),
+            "Please fix compiler errors in output above.",
+        )]
+    }
+}

--- a/ci/src/commands/doc.rs
+++ b/ci/src/commands/doc.rs
@@ -1,0 +1,19 @@
+use crate::{
+    commands::{DocCheckCommand, DocTestCommand},
+    Flag, Prepare, PreparedCommand,
+};
+use argh::FromArgs;
+
+/// Alias for running the `doc-test` and `doc-check` subcommands.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "doc")]
+pub struct DocCommand {}
+
+impl Prepare for DocCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let mut commands = vec![];
+        commands.append(&mut DocTestCommand::default().prepare(sh, flags));
+        commands.append(&mut DocCheckCommand::default().prepare(sh, flags));
+        commands
+    }
+}

--- a/ci/src/commands/doc_check.rs
+++ b/ci/src/commands/doc_check.rs
@@ -1,0 +1,21 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Checks that all docs compile.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "doc-check")]
+pub struct DocCheckCommand {}
+
+impl Prepare for DocCheckCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        vec![PreparedCommand::new::<Self>(
+            cmd!(
+                sh,
+                "cargo doc --workspace --all-features --no-deps --document-private-items --keep-going"
+            ),
+            "Please fix doc warnings in output above.",
+        )
+        .with_env_var("RUSTDOCFLAGS", "-D warnings")]
+    }
+}

--- a/ci/src/commands/doc_test.rs
+++ b/ci/src/commands/doc_test.rs
@@ -1,0 +1,22 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Runs all doc tests.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "doc-test")]
+pub struct DocTestCommand {}
+
+impl Prepare for DocTestCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let no_fail_fast = flags
+            .contains(Flag::KEEP_GOING)
+            .then_some("--no-fail-fast")
+            .unwrap_or_default();
+
+        vec![PreparedCommand::new::<Self>(
+            cmd!(sh, "cargo test --workspace --doc {no_fail_fast}"),
+            "Please fix failing doc tests in output above.",
+        )]
+    }
+}

--- a/ci/src/commands/format.rs
+++ b/ci/src/commands/format.rs
@@ -1,0 +1,17 @@
+use crate::{Flag, Prepare, PreparedCommand};
+use argh::FromArgs;
+use xshell::cmd;
+
+/// Check code formatting.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "format")]
+pub struct FormatCommand {}
+
+impl Prepare for FormatCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, _flags: Flag) -> Vec<PreparedCommand<'a>> {
+        vec![PreparedCommand::new::<Self>(
+            cmd!(sh, "cargo fmt --all -- --check"),
+            "Please run 'cargo fmt --all' to format your code.",
+        )]
+    }
+}

--- a/ci/src/commands/lints.rs
+++ b/ci/src/commands/lints.rs
@@ -1,0 +1,19 @@
+use crate::{
+    commands::{ClippyCommand, FormatCommand},
+    Flag, Prepare, PreparedCommand,
+};
+use argh::FromArgs;
+
+/// Alias for running the `format` and `clippy` subcommands.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "lints")]
+pub struct LintsCommand {}
+
+impl Prepare for LintsCommand {
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
+        let mut commands = vec![];
+        commands.append(&mut FormatCommand::default().prepare(sh, flags));
+        commands.append(&mut ClippyCommand::default().prepare(sh, flags));
+        commands
+    }
+}

--- a/ci/src/commands/mod.rs
+++ b/ci/src/commands/mod.rs
@@ -1,0 +1,24 @@
+// Compile commands
+mod compile;
+mod compile_check;
+
+pub use compile::*;
+pub use compile_check::*;
+
+// Documentation commands
+mod doc;
+mod doc_check;
+mod doc_test;
+
+pub use doc::*;
+pub use doc_check::*;
+pub use doc_test::*;
+
+// Lint commands
+mod clippy;
+mod format;
+mod lints;
+
+pub use clippy::*;
+pub use format::*;
+pub use lints::*;

--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -1,0 +1,13 @@
+//! CI script used for Forte.
+//!
+//! Copied from the bevy CI tool.
+
+mod ci;
+mod commands;
+mod prepare;
+
+pub use self::{ci::*, prepare::*};
+
+fn main() {
+    argh::from_env::<CI>().run();
+}

--- a/ci/src/prepare.rs
+++ b/ci/src/prepare.rs
@@ -1,0 +1,90 @@
+use bitflags::bitflags;
+
+/// Trait for preparing a subcommand to be run.
+pub trait Prepare {
+    /// A method that returns a list of [`PreparedCommand`]s to be run for a given shell and flags.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use crate::{Flag, Prepare, PreparedCommand};
+    /// # use argh::FromArgs;
+    /// # use xshell::Shell;
+    /// #
+    /// #[derive(FromArgs)]
+    /// #[argh(subcommand, name = "check")]
+    /// struct CheckCommand {}
+    ///
+    /// impl Prepare for CheckCommand {
+    ///     fn prepare<'a>(&self, sh: &'a Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
+    ///         vec![PreparedCommand::new::<Self>(
+    ///             cmd!(sh, "cargo check --workspace"),
+    ///             "Please fix linter errors",
+    ///         )]
+    ///     }
+    /// }
+    /// ```
+    fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>>;
+}
+
+bitflags! {
+    /// Flags that modify how commands are run.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct Flag: u32 {
+        /// Forces certain checks to continue running even if they hit an error.
+        const KEEP_GOING = 1 << 0;
+    }
+}
+
+/// A command with associated metadata, created from a command that implements [`Prepare`].
+#[derive(Debug)]
+pub struct PreparedCommand<'a> {
+    /// The name of the command.
+    pub name: &'static str,
+
+    /// The command to execute
+    pub command: xshell::Cmd<'a>,
+
+    /// The message to display if the test command fails
+    pub failure_message: &'static str,
+
+    /// The subdirectory path to run the test command within
+    pub subdir: Option<&'static str>,
+
+    /// Environment variables that need to be set before the test runs
+    pub env_vars: Vec<(&'static str, &'static str)>,
+}
+
+impl<'a> PreparedCommand<'a> {
+    /// Creates a new [`PreparedCommand`] from a [`Cmd`] and a failure message.
+    ///
+    /// The other fields of [`PreparedCommand`] are filled in with their default values.
+    ///
+    /// For more information about creating a [`Cmd`], please see the [`cmd!`](xshell::cmd) macro.
+    ///
+    /// [`Cmd`]: xshell::Cmd
+    pub fn new<T: argh::SubCommand>(
+        command: xshell::Cmd<'a>,
+        failure_message: &'static str,
+    ) -> Self {
+        Self {
+            command,
+            name: T::COMMAND.name,
+            failure_message,
+            subdir: None,
+            env_vars: vec![],
+        }
+    }
+
+    /// A builder that overwrites the current sub-directory with a new value.
+    pub fn with_subdir(mut self, subdir: &'static str) -> Self {
+        self.subdir = Some(subdir);
+        self
+    }
+
+    /// A builder that adds a new environmental variable to the list.
+    pub fn with_env_var(mut self, key: &'static str, value: &'static str) -> Self {
+        self.env_vars.push((key, value));
+        self
+    }
+}

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -1,4 +1,4 @@
-//! This is an example of how to integreat a threadpool with an external event
+//! This is an example of how to integrate a threadpool with an external event
 //! loop (winit in this case).
 
 use winit::{
@@ -37,8 +37,8 @@ impl ApplicationHandler<JobRef> for DemoApp {
 }
 
 fn main() {
-    // Resize the threadpool to the avalible number of threads.
-    COMPUTE.resize_to_avalible();
+    // Resize the threadpool to the available number of threads.
+    COMPUTE.resize_to_available();
 
     // Setup winit event loop.
     let event_loop = EventLoop::<JobRef>::with_user_event().build().unwrap();

--- a/src/job.rs
+++ b/src/job.rs
@@ -3,11 +3,11 @@
 //! (specifically a `JobRef`) is queued, passed to a thread, end executed.
 //!
 //! This module defines two core job types: `StackJob` and `HeapJob`. The former
-//! is more efficent, but can only be used when the work won't outlive the
+//! is more efficient, but can only be used when the work won't outlive the
 //! current stack. `HeapJob` requires an allocation, but can outlive the current
 //! stack.
 //!
-//! When using a job, one must be extreamly careful to ensure that:
+//! When using a job, one must be extremely careful to ensure that:
 //! (a) The job does not outlive anything it closes over.
 //! (b) The job remains valid until it is executed for the last time.
 //! (c) Each job reference is executed exactly once.
@@ -88,7 +88,7 @@ impl JobRef {
     /// Executes a `JobRef`.
     #[inline]
     pub fn execute(self) {
-        // SAFETY: The creator of the `JobRef` is reponsible for ensuring
+        // SAFETY: The creator of the `JobRef` is responsible for ensuring
         // `self.pointer` is valid up until this call and safe to pass to
         // `JobRef::execute_fn`. This consumes the `JobRef`, ensuring that if it
         // points to a `Job` then it is executed exactly one (given that the
@@ -131,10 +131,10 @@ where
     }
 
     /// Executes the job without having to go through the `JobRef`. This has the
-    /// benifit of saving some dynamic lookups, and allows the compiler to do
+    /// benefit of saving some dynamic lookup, and allows the compiler to do
     /// inline optimization (because the function type is known).
     ///
-    /// This is used in `join` to run the job syncrhonously after failing to
+    /// This is used in `join` to run the job synchronously after failing to
     /// share it.
     pub fn run_inline(self) {
         let job = self.job.into_inner().unwrap();
@@ -222,7 +222,7 @@ where
     ///
     /// Caller must ensure the `Box<HeapJob>` remains valid until the `JobRef`
     /// is executed. This hides all lifetimes, so the caller must ensure that it
-    /// dosn't outlive any data it closes over. Additionally, the caller must
+    /// doesn't outlive any data it closes over. Additionally, the caller must
     /// ensure that `JobRef::execute` is called exactly once.
     pub unsafe fn into_job_ref(self: Box<Self>) -> JobRef {
         // SAFETY: The caller ensures that the `JobRef` will remain valid until
@@ -240,7 +240,7 @@ where
     /// # Safety
     ///
     /// Caller must ensure that the pointer points to a valid raw boxed
-    /// `HeapJob`. Calling this compltes the job, so the caller must ensure that
+    /// `HeapJob`. Calling this completes the job, so the caller must ensure that
     /// this is called exactly once.
     unsafe fn execute(this: *const ()) {
         // SAFETY: The caller ensures that the pointer is a valid raw boxed heap

--- a/src/latch.rs
+++ b/src/latch.rs
@@ -24,11 +24,8 @@
 //! becomes "open", the logic it unblocks often deallocates the lock. Refer to
 //! specific safety comments for more information.
 
-use std::{
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-    sync::Arc,
-    task::Wake,
-};
+use alloc::{sync::Arc, task::Wake};
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use parking_lot::{Condvar, Mutex};
 
@@ -285,7 +282,7 @@ impl Latch for CountLatch {
         // it is fine if the pointer becomes dangling.
         unsafe {
             if (*this).counter.fetch_sub(1, Ordering::SeqCst) == 1 {
-                Latch::set(&(*this).latch)
+                Latch::set(&(*this).latch);
             }
         }
     }

--- a/src/latch.rs
+++ b/src/latch.rs
@@ -150,6 +150,8 @@ impl WakeLatch {
         }
     }
 
+    /// Creates a new latch from a thread pool and worker index, rather than
+    /// from a reference to a worker thread.
     #[inline]
     pub const fn new_raw(thread_index: usize, thread_pool: &'static ThreadPool) -> WakeLatch {
         WakeLatch {
@@ -299,7 +301,7 @@ impl Probe for CountLatch {
 // -----------------------------------------------------------------------------
 // Async set-on-wake
 
-// An async task waker that sets a latch on wake.
+/// An async task waker that sets a latch on wake.
 pub struct SetOnWake<L>
 where
     L: Latch,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 //! scheduling. Support for futures is based on an approach sketched out by
 //! members of the `rayon` community to whom we are deeply indebted.
 
+extern crate alloc;
+
 pub mod job;
 pub mod latch;
 pub mod scope;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod thread_pool;
 
 mod util;
 
+/// Exports a few commonly used types to simplify working with Forte.
 pub mod prelude {
     pub use crate::{
         scope::Scope,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,0 +1,54 @@
+//! A fast concurrent queue
+
+// This uses the same alignment as `CachePadded
+#[cfg(target_arch = "s390x", repr(align(256)))]
+const CACHE_LINE_SIZE: usize = 256;
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+))]
+const CACHE_LINE_SIZE: usize = 128;
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "arm",
+    target_arch = "mips",
+    target_arch = "mips32r6",
+    target_arch = "mips64",
+    target_arch = "mips64r6",
+    target_arch = "sparc",
+    target_arch = "hexagon",
+    target_arch = "m68k",
+    target_arch = "s390x",
+)))]
+const CACHE_LINE_SIZE: usize = 64;
+#[cfg(any(
+    target_arch = "arm",
+    target_arch = "mips",
+    target_arch = "mips32r6",
+    target_arch = "mips64",
+    target_arch = "mips64r6",
+    target_arch = "sparc",
+    target_arch = "hexagon",
+))]
+const CACHE_LINE_SIZE: usize = 32;
+#[cfg(target_arch = "m68k")]
+const CACHE_LINE_SIZE: usize = 16;
+
+pub struct Queue<T> {
+    // The head of the queue
+    head: CachePadded<AtomicU32>,
+    // The tail of the queue
+    tail: CachePadded<AtomicU32>,
+    // The buffer of pointers to T
+    buffer: Box<CachePadded<[UnsafeCell<MaybeUninit<T>>]>>,
+    // States for the buffer items, same length as buffer
+    states: Box<CachePadded<[AtomicI8]>>,
+}
+
+unsafe impl<T: Send> Send for Queue<T> {}
+unsafe impl<T: Send> Sync for Queue<T> {}
+
+impl<T> Queue<T> {}

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,3 +1,5 @@
+//! This module defines an utility for spawning lifetime-scoped jobs.
+
 use std::{future::Future, marker::PhantomData, ptr::NonNull};
 
 use async_task::{Runnable, Task};
@@ -266,6 +268,10 @@ impl<T> ScopePtr<T> {
     //
     // Callers must ensure the scope pointer is still valid.
     unsafe fn as_ref(&self) -> &T {
-        &*self.0
+        // SAFETY: The caller is required to ensure that the scope pointer is
+        // still valid.
+        unsafe {
+            &*self.0
+        }
     }
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -264,7 +264,7 @@ unsafe impl<T: Sync> Sync for ScopePtr<T> {}
 impl<T> ScopePtr<T> {
     // Helper to avoid disjoint captures of `scope_ptr.0`
     //
-    // # Saftey
+    // # Safety
     //
     // Callers must ensure the scope pointer is still valid.
     unsafe fn as_ref(&self) -> &T {

--- a/src/util.rs
+++ b/src/util.rs
@@ -103,13 +103,13 @@ impl<T> Slot<T> {
 
 impl<T> Drop for Slot<T> {
     fn drop(&mut self) {
-        // If `T` dosn't need to be dropped then neither does `Slot`.
+        // If `T` doesn't need to be dropped then neither does `Slot`.
         if needs_drop::<T>() {
             let Slot { flag, slot } = self;
             // SAFETY: The flag value is always set to either `NONE` or `SOME`.
             // Slots are never dropped when the flag is `LOCK`. If the flag is
             // `NONE` then the slot is empty and nothing needs to be dropped.
-            // If it is `SOME` then the value is initalized and we must
+            // If it is `SOME` then the value is initialized and we must
             // manually drop it.
             unsafe {
                 if *flag.get_mut() == SOME {
@@ -131,7 +131,7 @@ unsafe impl<T> Sync for Slot<T> where T: Send {}
 // -----------------------------------------------------------------------------
 // Xorshift fast prng (taken from rayon)
 
-/// [xorshift*] is a fast pseudorandom number generator which will
+/// [xorshift*] is a fast pseudo-random number generator which will
 /// even tolerate weak seeding, as long as it's not zero.
 ///
 /// [xorshift*]: https://en.wikipedia.org/wiki/Xorshift#xorshift*

--- a/src/util.rs
+++ b/src/util.rs
@@ -88,7 +88,7 @@ impl<T> Slot<T> {
             Ok(_) => {
                 let value;
                 // SAFETY: When the flag was `SOME` the value must be
-                // initalized. Since the slot is locked the duration, we know no
+                // initialized. Since the slot is locked the duration, we know no
                 // other threads can access the cell.
                 unsafe {
                     let slot = &mut *(self.slot.get());

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     cell::{Cell, UnsafeCell},
     mem::{needs_drop, MaybeUninit},
     sync::atomic::{AtomicUsize, Ordering},
@@ -65,6 +65,9 @@ impl<T> Slot<T> {
         {
             Err(_) => Some(value),
             Ok(_) => {
+                // SAFETY: When the flag was `NONE` the value must be
+                // uninitialized. Since the slot is locked for the duration we
+                // know no other threads can access the cell.
                 unsafe {
                     let slot = &mut *(self.slot.get());
                     slot.write(value);
@@ -84,6 +87,9 @@ impl<T> Slot<T> {
             Err(_) => None,
             Ok(_) => {
                 let value;
+                // SAFETY: When the flag was `SOME` the value must be
+                // initalized. Since the slot is locked the duration, we know no
+                // other threads can access the cell.
                 unsafe {
                     let slot = &mut *(self.slot.get());
                     value = slot.assume_init_read();


### PR DESCRIPTION
Adds a CI tool modeled off the one bevy uses. Includes some changes to the codebase to make it pass lint. One of the lints for `unsafe` blocks caused to to re-evaluate some of the existing safety comments, I think for the better. 

A full pass on the safety comments for `JobRef` is probably needed at some point.

# Example

Just with bevy, CI can be run locally with `cargo run -p ci`. Specific tasks can be run by passing in a command after the double dash, for example `cargo run -p ci -- doc`. 

# Future Work

The next steps are to get some better tests, hook up a test runner, and integrate `loom` and `miri`.