### PR TITLE
Remove Implicit `std` Prelude

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -12,6 +12,7 @@
 //! (b) The job remains valid until it is executed for the last time.
 //! (c) Each job reference is executed exactly once.
 
+use alloc::boxed::Box;
 use core::cell::UnsafeCell;
 
 // -----------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@
 //! scheduling. Support for futures is based on an approach sketched out by
 //! members of the `rayon` community to whom we are deeply indebted.
 
+#![no_std]
+
+extern crate std;
+
 extern crate alloc;
 
 pub mod job;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,5 +1,6 @@
 //! This module defines an utility for spawning lifetime-scoped jobs.
 
+use alloc::boxed::Box;
 use core::{future::Future, marker::PhantomData, ptr::NonNull};
 
 use async_task::{Runnable, Task};

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -13,7 +13,7 @@ use core::{
     task::{Context, Poll},
     time::Duration,
 };
-use std::thread;
+use std::{thread, thread_local};
 
 use async_task::{Runnable, Task};
 use crossbeam_queue::SegQueue;


### PR DESCRIPTION
Not an actual `no_std` PR, just removes the last implicit `std` includes, making it clear which module is the problematic one.