### PR TITLE
Add badges and switch to `-dev` version prefix on main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forte"
-version = "1.0.0-alpha.3"
+version = "1.0.0-dev"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A low-overhead thread-pool with support for non-static async closures"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Forte
 
+[![Crates.io](https://img.shields.io/crates/v/forte.svg)](https://crates.io/crates/forte)
+[![Docs](https://docs.rs/forte/badge.svg)](https://docs.rs/forte/latest/forte/)
+
 An async-compatible thread-pool aiming for "speed through simplicity".
 
 Forte is a parallel & async work scheduler designed to accommodate very large workloads with many short-lived tasks. It replicates the `rayon_core` api but with native support for futures and async tasks. 


### PR DESCRIPTION
Adds docs.rs and crates.io batches, switches the version from `1.0.0-alpha.3` to `1.0.0-dev`. From now on, I'll be cutting a branch for releases and setting the version manually before publish.