### PR TITLE
Add rayon compatability crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ This project is currently in early [pre-release], and there may be arbitrary bre
 
 ## [Unreleased]
 
+### Added
+
+- `rayon-compat` crate, for running rayon on top of forte.
+- `Worker::migrated()` which is `true` when the current job has moved between threads.
+
+### Changed
+
+- Heartbeat frequency is now 100 microseconds.
+- Heartbeats are now more evenly distributed between workers.
+- The heartbeat thread goes to sleep when the pool is not in use.
+- Shared work is now queued and claimed in the order it was shared.
+- The `Scope` API is now identical to `rayon-core` and does not use `Pin<T>`.
+- `Scope::new`, `Scope::add_reference` and `Scope::remove_reference` are now private.
+
+### Security
+
+- Forte now implements exception safety. Panics can no longer cause UB.
+
 ## [1.0.0-alpha.3]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-compat"
+version = "1.12.1"
+dependencies = [
+ "forte",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/NthTensor/Forte"
 
 [workspace]
 resolver = "2"
-members = ["ci"]
-exclude = ["coz"]
+members = ["ci", "rayon-compat"]
 
 [dependencies]
 async-task = "4.7.1"

--- a/rayon-compat/Cargo.toml
+++ b/rayon-compat/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rayon-compat"
+version = "1.12.1"
+edition = "2024"
+
+[dependencies]
+forte = { path = ".." }
+
+[features]
+web_spin_lock = []

--- a/rayon-compat/README.md
+++ b/rayon-compat/README.md
@@ -1,0 +1,14 @@
+# Rayon Compat
+
+This is a way to run `rayon` on top of `forte`! The `rayon-compat` crate mocks the important bits of the api of `rayon_core` in a pretty simple and crude way, which is none-the-less enough to support most of what `rayon` needs.
+
+To use this crate, apply the following cargo patch like one of these:
+```
+// If you want to clone forte and use it locally
+[patch.crates-io]
+rayon-core = { path = "path to this repo", package = "rayon-compat" }
+
+// If you want to use the latest published version of forte
+[patch.crates-io]
+rayon-core = { path = "https://github.com/NthTensor/Forte", package = "rayon-compat" }
+```

--- a/rayon-compat/src/lib.rs
+++ b/rayon-compat/src/lib.rs
@@ -1,0 +1,171 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub static THREAD_POOL: forte::ThreadPool = const { forte::ThreadPool::new() };
+
+pub static STARTED: AtomicBool = const { AtomicBool::new(false) };
+
+#[inline(always)]
+fn ensure_started() {
+    if !STARTED.load(Ordering::Relaxed) && !STARTED.swap(true, Ordering::Relaxed) {
+        THREAD_POOL.resize_to_available();
+    }
+}
+
+#[inline(always)]
+pub fn current_num_threads() -> usize {
+    64 // Forte prefers smaller tasks, so it's better to lie to rayon about the size of the pool
+}
+
+#[inline(always)]
+pub fn current_thread_index() -> Option<usize> {
+    forte::Worker::map_current(|worker| worker.index())
+}
+
+#[inline(always)]
+pub fn max_num_threads() -> usize {
+    usize::MAX // The number of forte workers is only bounded by the size of a vector.
+}
+
+// -----------------------------------------------------------------------------
+// Join
+
+#[derive(Debug)]
+pub struct FnContext {
+    /// True if the task was migrated.
+    migrated: bool,
+}
+
+impl FnContext {
+    #[inline(always)]
+    pub fn migrated(&self) -> bool {
+        self.migrated
+    }
+}
+
+#[inline(always)]
+pub fn join_context<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+where
+    A: FnOnce(FnContext) -> RA + Send,
+    B: FnOnce(FnContext) -> RB + Send,
+    RA: Send,
+    RB: Send,
+{
+    ensure_started();
+    THREAD_POOL.join(
+        |worker| {
+            let migrated = worker.migrated();
+            let ctx = FnContext { migrated };
+            oper_a(ctx)
+        },
+        |worker| {
+            let migrated = worker.migrated();
+            let ctx = FnContext { migrated };
+            oper_b(ctx)
+        },
+    )
+}
+
+#[inline(always)]
+pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
+where
+    A: FnOnce() -> RA + Send,
+    B: FnOnce() -> RB + Send,
+    RA: Send,
+    RB: Send,
+{
+    ensure_started();
+    THREAD_POOL.join(|_| oper_a(), |_| oper_b())
+}
+
+// -----------------------------------------------------------------------------
+// Scope
+
+pub use forte::Scope;
+
+#[inline(always)]
+pub fn scope<'scope, OP, R>(op: OP) -> R
+where
+    OP: FnOnce(&Scope<'scope>) -> R + Send,
+    R: Send,
+{
+    ensure_started();
+    forte::scope(op)
+}
+
+#[inline(always)]
+pub fn in_place_scope<'scope, OP, R>(op: OP) -> R
+where
+    OP: FnOnce(&Scope<'scope>) -> R,
+{
+    ensure_started();
+    forte::scope(op)
+}
+
+// -----------------------------------------------------------------------------
+// Spawn
+
+#[inline(always)]
+pub fn spawn<F>(func: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    ensure_started();
+    THREAD_POOL.spawn(|_| func())
+}
+
+// -----------------------------------------------------------------------------
+// Yield
+
+pub use forte::Yield;
+
+pub fn yield_local() -> Yield {
+    let result = forte::Worker::map_current(forte::Worker::yield_local);
+    match result {
+        Some(status) => status,
+        _ => Yield::Idle,
+    }
+}
+
+pub fn yield_now() -> Yield {
+    let result = forte::Worker::map_current(forte::Worker::yield_now);
+    match result {
+        Some(status) => status,
+        _ => Yield::Idle,
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Fake stuff that dosn't work. These are here only so so that rayon can export
+// them.
+
+pub struct ThreadBuilder;
+
+pub struct ThreadPool;
+
+pub struct ThreadPoolBuildError;
+
+pub struct ThreadPoolBuilder;
+
+pub struct BroadcastContext;
+
+pub struct ScopeFifo;
+
+pub fn broadcast() {
+    unimplemented!()
+}
+
+pub fn spawn_broadcast() {
+    unimplemented!()
+}
+
+pub fn scope_fifo() {
+    unimplemented!()
+}
+
+pub fn in_place_scope_fifo() {
+    unimplemented!()
+}
+
+pub fn spawn_fifo() {
+    unimplemented!()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod job;
 mod scope;
 mod signal;
 mod thread_pool;
+mod unwind;
 
 // -----------------------------------------------------------------------------
 // Top-level exports

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -1,0 +1,37 @@
+//! Unwinding recovery utilities taken from rayon.
+
+use alloc::boxed::Box;
+use core::any::Any;
+use core::panic::AssertUnwindSafe;
+use std::eprintln;
+use std::panic::catch_unwind;
+use std::panic::resume_unwind;
+use std::process::abort;
+use std::thread::Result;
+
+/// Executes `f` and captures any panic, translating that panic into a
+/// `Err` result. The assumption is that any panic will be propagated
+/// later with `resume_unwinding`, and hence `f` can be treated as
+/// exception safe.
+#[cold]
+pub fn halt_unwinding<F, R>(func: F) -> Result<R>
+where
+    F: FnOnce() -> R,
+{
+    catch_unwind(AssertUnwindSafe(func))
+}
+
+#[cold]
+pub fn resume_unwinding(payload: Box<dyn Any + Send>) -> ! {
+    resume_unwind(payload)
+}
+
+/// Aborts the program when dropped.
+pub struct AbortOnDrop;
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        eprintln!("Forte: detected unexpected panic; aborting");
+        abort();
+    }
+}


### PR DESCRIPTION
Adds `rayon-compat`, the world's worst implementation of `rayon-core`.

Using this crate, it's possible to run a good amount of the `rayon` library on top of forte. Programs that use `rayon` will compile using this patch, but may crash unexpectedly and/or have UB. So don't, like, use this in production.