### PR TITLE
Fix CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "forte"
-version = "1.0.0-alpha.3"
+version = "1.0.0-dev"
 dependencies = [
  "async-task",
  "atomic-wait",

--- a/ci/src/commands/doc_test.rs
+++ b/ci/src/commands/doc_test.rs
@@ -12,10 +12,11 @@ pub struct DocTestCommand {}
 
 impl Prepare for DocTestCommand {
     fn prepare<'a>(&self, sh: &'a xshell::Shell, flags: Flag) -> Vec<PreparedCommand<'a>> {
-        let no_fail_fast = flags
-            .contains(Flag::KEEP_GOING)
-            .then_some("--no-fail-fast")
-            .unwrap_or_default();
+        let no_fail_fast = if flags.contains(Flag::KEEP_GOING) {
+            "--no-fail-fast"
+        } else {
+            ""
+        };
 
         vec![PreparedCommand::new::<Self>(
             cmd!(sh, "cargo test --workspace --doc {no_fail_fast}"),


### PR DESCRIPTION
A recent rust version added a lint that was failing CI (in the CI crate, funnily enough). This fixes it.