### PR TITLE
Scope overhaul

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ mod platform {
     pub use alloc::sync::Arc;
     pub use alloc::sync::Weak;
     pub use core::sync::atomic::AtomicBool;
+    pub use core::sync::atomic::AtomicPtr;
     pub use core::sync::atomic::AtomicU32;
     pub use core::sync::atomic::Ordering;
     pub use std::sync::Barrier;
@@ -95,6 +96,7 @@ mod platform {
     pub use shuttle::sync::Mutex;
     pub use shuttle::sync::Weak;
     pub use shuttle::sync::atomic::AtomicBool;
+    pub use shuttle::sync::atomic::AtomicPtr;
     pub use shuttle::sync::atomic::AtomicU32;
     pub use shuttle::sync::atomic::Ordering;
     pub use shuttle::thread::Builder as ThreadBuilder;

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -2,71 +2,102 @@
 //! information see [`crate::scope()`] or the [`Scope`] type.
 
 use alloc::boxed::Box;
+use core::any::Any;
 use core::future::Future;
 use core::marker::PhantomData;
-use core::marker::PhantomPinned;
+use core::ptr;
 
 use async_task::Runnable;
 use async_task::Task;
 use scope_ptr::ScopePtr;
 
+use crate::ThreadPool;
 use crate::job::HeapJob;
 use crate::job::JobRef;
 use crate::platform::*;
 use crate::signal::Signal;
 use crate::thread_pool::Worker;
+use crate::unwind;
+use crate::unwind::AbortOnDrop;
 
 // -----------------------------------------------------------------------------
 // Scope
 
-/// A scope which can spawn a number of non-static jobs and async tasks. See
-/// [`ThreadPool::scope`](crate::ThreadPool::scope) for more information.
-pub struct Scope<'scope> {
+/// A scope which can spawn a number of non-static jobs and async tasks.
+pub struct Scope<'scope, 'env: 'scope> {
     /// Number of active references to the scope (including the owning
     /// allocation). This is incremented each time a new `ScopePtr` is created,
-    /// and decremented when a `ScopePtr` or the `Scope` itself is dropped.
+    /// and decremented when a `ScopePtr` is dropped or the owning thead is done
+    /// using it.
     count: AtomicU32,
     /// A signal used to communicate when the scope has been completed.
     signal: Signal,
-    /// A marker that makes the scope behave as if it contained a vector of
-    /// closures to execute, all of which outlive `'scope`. We pretend they are
-    /// `Send + Sync` even though they're not actually required to be `Sync`.
-    /// It's still safe to let the `Scope` implement `Sync` because the closures
-    /// are only *moved* across threads to be executed.
-    #[allow(clippy::type_complexity)]
-    _marker: PhantomData<Box<dyn FnOnce(&Scope<'scope>) + Send + Sync + 'scope>>,
-    /// Opt out of Unpin behavior; this type requires strong pinning guaranties.
-    _phantom: PhantomPinned,
+    /// If any job panics, we store the result here to propagate it.
+    panic: AtomicPtr<Box<dyn Any + Send + 'static>>,
+    /// Makes `Scope` invariant over 'scope
+    _scope: PhantomData<&'scope mut &'scope ()>,
+    /// Makes `Scope` invantiant over 'env
+    _env: PhantomData<&'env mut &'env ()>,
 }
 
-impl<'scope> Scope<'scope> {
-    /// Creates a new scope owned by the given worker thread. For a safe
-    /// equivalent, use [`ThreadPool::scope`](crate::ThreadPool::scope).
-    ///
-    /// Every scope contains a lifetime `'scope`, which must outlive anything
-    /// spawned onto the scope.
-    ///
-    /// When a scope is dropped, it will block the thread until all work
-    /// spawened on the scope is complete.
+/// Crates a new scope on a worker. [`Worker::scope`] is just an alias for this
+/// function.
+#[inline]
+pub fn with_scope<'env, F, T>(worker: &Worker, f: F) -> T
+where
+    F: for<'scope> FnOnce(&'scope Scope<'scope, 'env>) -> T,
+{
+    let abort_guard = AbortOnDrop;
+    // SAFETY: The scope is never moved or mutably referenced. The scope is only
+    // dropped at the end of this function, after the call to `complete`. The
+    // abort guard above prevents the stack from being dropped early during a
+    // panic unwind.
+    let scope = unsafe { Scope::new() };
+    // Panics that occur within the closure should be caught and propagated once
+    // all spawned work is complete. This is not a safety requirement, it's just
+    // a nicer behavior than aborting.
+    let result = match unwind::halt_unwinding(|| f(&scope)) {
+        Ok(value) => Some(value),
+        Err(err) => {
+            scope.store_panic(err);
+            None
+        }
+    };
+    // Now that the user has (presuamably) spawnd some work onto the scope, we
+    // must wait for it to complete.
+    //
+    // SAFETY: This is called only once.
+    unsafe { scope.complete(worker) };
+    // At this point all work on the scope is complete, so it is safe to drop
+    // the scope. This also means we can relinquish our abort guard (returning
+    // to the normal panic behavior).
+    core::mem::forget(abort_guard);
+    // If the closure or any spawned work did panic, we can now panic.
+    scope.maybe_propagate_panic();
+    // Otherwise return the result of evaluating the closure.
+    result.unwrap()
+}
+
+impl<'scope, 'env> Scope<'scope, 'env> {
+    /// Creates a new scope
     ///
     /// # Safety
     ///
-    /// The caller must pin the scope before it can be used (This cannot be
-    /// enforced on the type-level due to compatibility requirements with rayon)
-    /// and must ensure the scope is eventually dropped.
-    pub(crate) unsafe fn new() -> Scope<'scope> {
+    /// The caller must promise not to move or mutably reference this scope
+    /// until it is dropped, and must not allow the scope to be dropped until
+    /// after `Scope::complete` is run and returns.
+    unsafe fn new() -> Scope<'scope, 'env> {
         Scope {
             count: AtomicU32::new(1),
             signal: Signal::new(),
-            _marker: PhantomData,
-            _phantom: PhantomPinned,
+            panic: AtomicPtr::new(ptr::null_mut()),
+            _scope: PhantomData,
+            _env: PhantomData,
         }
     }
 
-    /// Spawns a job into the scope. This job will execute sometime before the
-    /// scope completes. The job is specified as a closure, and this closure
-    /// receives its own reference to the scope `self` as argument. This can be
-    /// used to inject new jobs into `self`.
+    /// Spawns a scoped job onto the local worker. This job will execute
+    /// sometime before the scope completes.
     ///
     /// # Returns
     ///
@@ -76,45 +107,34 @@ impl<'scope> Scope<'scope> {
     /// channels.
     ///
     /// If you need to return a value, spawn a `Future` instead with
-    /// [`Scope::spawn_future`].
+    /// [`Scope::spawn_future_on`].
     ///
-    /// # See also
-    ///
-    /// The [`ThreadPool::scope`](crate::ThreadPool::scope) function has more
-    /// extensive documentation about task spawning.
-    ///
-    /// # Panics
-    ///
-    /// Panics if not called from within a worker.
-    ///
-    pub fn spawn<F>(&self, f: F)
+    pub fn spawn_on<F>(&self, worker: &Worker, f: F)
     where
-        F: FnOnce(&Scope<'scope>) + Send + 'scope,
+        F: FnOnce(&Worker) + Send + 'scope,
     {
         // Create a job to execute the spawned function in the scope.
-        //
-        // SAFETY: This scope must be pinned, since the only way to create a
-        // scope is via `Scope::new` and that function requires the caller pin
-        // the scope before using it.
-        let scope_ptr = unsafe { ScopePtr::new(self) };
-        let job = HeapJob::new(move |_| {
-            scope_ptr.run(f);
+        let scope_ptr = ScopePtr::new(self);
+        let job = HeapJob::new(move |worker| {
+            // Catch any panics and store them on the scope.
+            let result = unwind::halt_unwinding(|| f(worker));
+            if let Err(err) = result {
+                scope_ptr.store_panic(err);
+            };
+            drop(scope_ptr);
         });
 
         // SAFETY: We must ensure that the heap job does not outlive the data it
         // closes over. In effect, this means it must not outlive `'scope`.
         //
-        // The `'scope` will last until the scope is deallocated, which (due to
-        // reference counting) will not be until after `scope_ptr` within the
-        // heap job is dropped. So `'scope` should last at least until the heap
-        // job is dropped.
+        // This is ensured by the `scope_ptr` and the scope rules, which will
+        // keep the calling stack frame alive until this job completes,
+        // effectively extending the lifetime of `'scope` for as long as is
+        // nessicary.
         let job_ref = unsafe { job.into_job_ref() };
 
         // Send the job to a queue to be executed.
-        Worker::with_current(|worker| {
-            let worker = worker.unwrap();
-            worker.queue.push_back(job_ref);
-        });
+        worker.queue.push_back(job_ref);
     }
 
     /// Spawns a future onto the scope. This future will be asynchronously
@@ -143,43 +163,18 @@ impl<'scope> Scope<'scope> {
     ///    infinite loop will prevent the scope from completing, and is not
     ///    recommended.
     ///
-    /// # Panics
-    ///
-    /// Panics if not called within a worker.
-    ///
-    pub fn spawn_future<F, T>(&self, future: F) -> Task<T>
+    pub fn spawn_future_on<F, T>(&self, thread_pool: &'static ThreadPool, future: F) -> Task<T>
     where
         F: Future<Output = T> + Send + 'scope,
-        T: Send + 'scope,
+        T: Send,
     {
-        self.spawn_async(|_| future)
-    }
-
-    /// Spawns an async closure onto the scope. This future will be
-    /// asynchronously polled to completion some time before the scope
-    /// completes.
-    ///
-    /// Internally the closure is wrapped into a future and passed along to
-    /// [`Scope::spawn_future`]. See the docs on that function for more
-    /// information.
-    ///
-    /// # Panics
-    ///
-    /// Panics if not called within a worker.
-    ///
-    pub fn spawn_async<Fn, Fut, T>(&self, f: Fn) -> Task<T>
-    where
-        Fn: FnOnce(&Scope<'scope>) -> Fut + Send + 'scope,
-        Fut: Future<Output = T> + Send + 'scope,
-        T: Send + 'scope,
-    {
-        // Wrap the function into a future using an async block.
-        //
-        // SAFETY: This scope must be pinned, since the only way to create a
-        // scope is via `Scope::new` and that function requires the caller pin
-        // the scope before using it.
-        let scope_ptr = unsafe { ScopePtr::new(self) };
-        let future = async move { scope_ptr.run(f).await };
+        // Embed the scope pointer into the future.
+        let scope_ptr = ScopePtr::new(self);
+        let future = async move {
+            let result = future.await;
+            drop(scope_ptr);
+            result
+        };
 
         // The schedule function will turn the future into a job when woken.
         let schedule = move |runnable: Runnable| {
@@ -201,8 +196,7 @@ impl<'scope> Scope<'scope> {
             // local queue, which will generally cause tasks to stick to the
             // same thread instead of jumping around randomly. This is also
             // faster than injecting into the global queue.
-            Worker::with_current(|worker| {
-                let worker = worker.unwrap();
+            thread_pool.with_worker(|worker| {
                 worker.queue.push_back(job_ref);
             });
         };
@@ -210,11 +204,10 @@ impl<'scope> Scope<'scope> {
         // SAFETY: We must ensure that the runnable does not outlive the data it
         // closes over. In effect, this means it must not outlive `'scope`.
         //
-        // The `'scope` will last until the scope is deallocated, which (due to
-        // reference counting) will not be until after `scope_ptr` within the
-        // future is dropped. The future will not be dropped until after the
-        // runnable is dropped, so `'scope` should last at least until the
-        // runnable is dropped.
+        // This is ensured by the `scope_ptr` and the scope rules, which will
+        // keep the calling stack frame alive until the runnable is dropped,
+        // effectively extending the lifetime of `'scope` for as long as is
+        // nessicary.
         //
         // We have to use `spawn_unchecked` here instead of `spawn` because the
         // future is non-static.
@@ -233,7 +226,7 @@ impl<'scope> Scope<'scope> {
     /// `Scope::remove_reference`, or the scope will block forever on
     /// completion.
     fn add_reference(&self) {
-        let counter = self.count.fetch_add(1, Ordering::SeqCst);
+        let counter = self.count.fetch_add(1, Ordering::Release);
         tracing::trace!("scope reference counter increased to {}", counter + 1);
     }
 
@@ -245,7 +238,7 @@ impl<'scope> Scope<'scope> {
     /// `add_reference` for every call to this function, unless used within
     /// `Scope::complete`.
     unsafe fn remove_reference(&self) {
-        let counter = self.count.fetch_sub(1, Ordering::SeqCst);
+        let counter = self.count.fetch_sub(1, Ordering::Acquire);
         tracing::trace!("scope reference counter decreased to {}", counter - 1);
         if counter == 1 {
             // Alerts the owning thread that the scope has completed.
@@ -259,22 +252,61 @@ impl<'scope> Scope<'scope> {
             unsafe { Signal::send(&self.signal, ()) };
         }
     }
-}
 
-impl Drop for Scope<'_> {
-    fn drop(&mut self) {
-        // When the scope is dropped, block to prevent deallocation until the
-        // reference counter allows the scope to complete.
-        tracing::trace!("completing scope");
+    /// Stores a panic so that it can be propagated when the scope is complete.
+    /// If called multiple times, only the first panic is stored, and the
+    /// remainder are dropped.
+    fn store_panic(&self, err: Box<dyn Any + Send + 'static>) {
+        if self.panic.load(Ordering::Relaxed).is_null() {
+            let nil = ptr::null_mut();
+            let err_ptr = Box::into_raw(Box::new(err));
+            if self
+                .panic
+                .compare_exchange(nil, err_ptr, Ordering::Release, Ordering::Relaxed)
+                .is_ok()
+            {
+                // Ownership is now transferred into the panic field.
+            } else {
+                // Another panic raced in ahead of us, so we need to drop this one.
+                //
+                // SAFETY: This was created by `Box::into_raw` just above. It is
+                // possible that this will panic, because it's a `Box<dyn Any>`,
+                // however in the worst case this will simply trigger the
+                // scope's abort guard, causing an abort rather than UB.
+                let _: Box<_> = unsafe { Box::from_raw(err_ptr) };
+            }
+        }
+    }
+
+    /// Propagates any panic captured while the scope was executing.
+    fn maybe_propagate_panic(&self) {
+        let panic = self.panic.swap(ptr::null_mut(), Ordering::Relaxed);
+        if !panic.is_null() {
+            // SAFETY: This was created by `Box::into_raw` in `store_panic` and,
+            // because of the atomic swap just above, is only called once for
+            // each box.
+            let value = unsafe { Box::from_raw(panic) };
+            unwind::resume_unwinding(*value);
+        }
+    }
+
+    /// Waits for the scope to complete.
+    ///
+    /// # Safety
+    ///
+    /// This must be called only once.
+    unsafe fn complete(&self, worker: &Worker) {
         // SAFETY: This is explicitly allowed, because every scope starts off
-        // with a counter of 1. This should be the only call to
-        // `remove_reference` without a corresponding call to `add_reference`, so
-        // the only one that can cause the reference counter to drop to zero.
+        // with a counter of 1. Because this is called only once, the following
+        // should be the only call to `remove_reference` without a corresponding
+        // call to `add_reference`.
+        //
+        // Only after the following call will the counter decrement to zero,
+        // causing the signal to become set and allowing this function to
+        // return.
         unsafe { self.remove_reference() };
-        Worker::with_current(|worker| {
-            let worker = worker.unwrap();
-            worker.wait_for_signal(&self.signal);
-        });
+        // Wait for the remaining work to complete.
+        worker.wait_for_signal(&self.signal);
     }
 }
 
@@ -284,81 +316,132 @@ impl Drop for Scope<'_> {
 mod scope_ptr {
     //! Defines a "lifetime-erased" reference-counting pointer to a scope.
 
+    use alloc::boxed::Box;
+    use core::any::Any;
+
     use super::Scope;
 
     /// A reference-counted pointer to a scope. Used to capture a scope pointer
     /// in jobs without faking a lifetime. Holding a `ScopePtr` keeps the
     /// reference scope from being deallocated.
-    pub struct ScopePtr<'scope>(*const Scope<'scope>);
+    pub struct ScopePtr<'scope, 'env>(*const Scope<'scope, 'env>);
 
     // SAFETY: !Send for raw pointers is not for safety, just as a lint.
-    unsafe impl Send for ScopePtr<'_> {}
+    unsafe impl Send for ScopePtr<'_, '_> {}
 
     // SAFETY: !Sync for raw pointers is not for safety, just as a lint.
-    unsafe impl Sync for ScopePtr<'_> {}
+    unsafe impl Sync for ScopePtr<'_, '_> {}
 
-    impl<'scope> ScopePtr<'scope> {
+    impl<'scope, 'env> ScopePtr<'scope, 'env> {
         /// Creates a new reference-counted scope pointer which can be sent to other
         /// threads.
-        ///
-        /// # SAFETY:
-        ///
-        /// The scope must be pinned (this cannot be enforced on the type level
-        /// due to compatibility requirements with rayon).
-        pub unsafe fn new(scope: &Scope<'scope>) -> ScopePtr<'scope> {
+        pub fn new(scope: &Scope<'scope, 'env>) -> ScopePtr<'scope, 'env> {
+            // Add a reference to ensure the scope will stay alive at least
+            // until this is dropped (which we will decrement the counter).
             scope.add_reference();
             ScopePtr(scope)
         }
 
-        /// Passes the scope referred to by this pointer into a closure.
-        pub fn run<F, T>(&self, f: F) -> T
-        where
-            F: FnOnce(&Scope<'scope>) -> T + 'scope,
-        {
-            // SAFETY: This pointer is convertible to a shared reference.
-            //
-            // + It was created from an immutable reference to a pinned scope.
-            //   The only way for this to be invalidated is if the scope was
-            //   dropped in the time since we created the pointer.
-            //
-            // + We incremented the scope's reference counter and will not
-            //   decrement it until this pointer is dropped. Since the scope
-            //   will not be dropped while the reference counter is above
-            //   zero, we know the pointer is still valid.
-            //
-            // + The scope is never accessed mutably, so creating shared
-            //   references is allowed.
-            //
+        /// Stores a panic in the scope that can be resumed later.
+        pub fn store_panic(&self, err: Box<dyn Any + Send + 'static>) {
+            // SAFETY: This was created using an immutable scope reference, and
+            // by the scope rules there can be no mutable references to this
+            // scope, nor can the scope have been moved or deallocated while the
+            // scope's counter remains incremented.
             let scope_ref = unsafe { &*self.0 };
-
-            // Execute the closure on the shared reference.
-            f(scope_ref)
+            scope_ref.store_panic(err);
         }
     }
 
-    impl Drop for ScopePtr<'_> {
+    impl Drop for ScopePtr<'_, '_> {
         fn drop(&mut self) {
-            // SAFETY: This pointer is convertible to a shared reference.
-            //
-            // + It was created from an immutable reference to a pinned scope.
-            //   The only way for this to be invalidated is if the scope was
-            //   dropped in the time since we created the pointer.
-            //
-            // + We incremented the scope's reference counter and will not
-            //   decrement it until this pointer is dropped. Since the scope
-            //   will not be dropped while the reference counter is above
-            //   zero, we know the pointer is still valid.
-            //
-            // + The scope is never accessed mutably, so creating shared
-            //   references is allowed.
-            //
+            // SAFETY: This was created using an immutable scope reference, and
+            // by the scope rules there can be no mutable references to this
+            // scope, nor can the scope have been moved or deallocated while the
+            // scope's counter remains incremented.
             let scope_ref = unsafe { &*self.0 };
 
-            // Decrement the reference counter, possibly allowing the scope to
-            // complete.
+            // Decrement the reference counter, possibly allowing
+            // `Scope::complete` to return and the scope itself to be freed.
             //
             // SAFETY: We call `add_reference` in `ScopePtr::new`.
             unsafe { scope_ref.remove_reference() };
         }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+
+#[cfg(all(test, not(feature = "shuttle")))]
+mod tests {
+    use core::sync::atomic::AtomicU8;
+    use core::sync::atomic::Ordering;
+
+    use crate::ThreadPool;
+    use crate::scope;
+
+    #[test]
+    fn scoped_borrow() {
+        static THREAD_POOL: ThreadPool = ThreadPool::new();
+        THREAD_POOL.populate();
+
+        let mut string = "a";
+        THREAD_POOL.with_worker(|worker| {
+            scope(|scope| {
+                scope.spawn_on(worker, |_| {
+                    string = "b";
+                })
+            });
+        });
+        assert_eq!(string, "b");
+    }
+
+    #[test]
+    fn scoped_borrow_twice() {
+        static THREAD_POOL: ThreadPool = ThreadPool::new();
+        THREAD_POOL.populate();
+
+        let mut string = "a";
+        THREAD_POOL.with_worker(|worker| {
+            scope(|scope| {
+                scope.spawn_on(worker, |worker| {
+                    string = "b";
+                    scope.spawn_on(worker, |_| {
+                        string = "c";
+                    })
+                })
+            });
+        });
+        assert_eq!(string, "c");
+    }
+
+    #[test]
+    fn scoped_concurrency() {
+        const NUM_JOBS: u8 = 128;
+
+        static THREAD_POOL: ThreadPool = ThreadPool::new();
+        THREAD_POOL.resize_to(4);
+
+        let a = AtomicU8::new(0);
+        let b = AtomicU8::new(0);
+
+        THREAD_POOL.with_worker(|worker| {
+            scope(|scope| {
+                for _ in 0..NUM_JOBS {
+                    scope.spawn_on(worker, |_| {
+                        THREAD_POOL.join(
+                            |_| a.fetch_add(1, Ordering::Relaxed),
+                            |_| b.fetch_add(1, Ordering::Relaxed),
+                        );
+                    });
+                }
+            });
+        });
+
+        assert_eq!(a.load(Ordering::Relaxed), NUM_JOBS);
+        assert_eq!(b.load(Ordering::Relaxed), NUM_JOBS);
+
+        THREAD_POOL.depopulate();
     }
 }


### PR DESCRIPTION
This is a large-scale overhaul of the scope implementation.
+ Loosen an overly restrictive memory ordering for the scope counter.
+ Switch from rayon-style to bevy-style scopes (two lifetimes instead of one). This allows references to scopes to be passed around more freely, and will reduce migration pain down the road.
+ Make scopes properly panic safe by porting over the panic propagation from rayon.
+ Pass the worker to blocking tasks spawned on scopes, just like we do for static tasks.
+ Clean up documentation and generally spruce things up a bit.
+ Remove pointless use of `pin` in favor of an unsafe assertion that scopes don't move. `Pin` turned out to be far more haste than it was worth.
+ Remove the ability to spawn async functions on scopes. I'll be removing this from thread pool soon as well. Futures are simpler to work with, and this created some nontrivial duplication for little benefit.