### PR TITLE
Allow dependents to disable the tracing-disabling feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ atomic-wait = "1.1.0"
 crossbeam-queue = "0.3.12"
 crossbeam-utils = "0.8.21"
 shuttle = { version = "0.8.0", optional = true }
-tracing = { version = "0.1.41", features = ["release_max_level_off"] }
+tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 
 [dev-dependencies]
@@ -30,7 +30,9 @@ bevy_tasks = { version = "0.16.1", features = [ "multi_threaded" ] }
 criterion = { version = "0.5" }
 
 [features]
+default = ["tracing_max_level_off"]
 shuttle = ["dep:shuttle"]
+tracing_max_level_off = ["tracing/release_max_level_off"]
 
 [profile.release]
 debug = true


### PR DESCRIPTION
Hi!

Thanks for writing this crate, it's been very useful to me.
Having the `release_max_level_off` feature of tracing enabled disables tracing in release for dependents of this crate.

This PR exposes it as default feature so that dependents can disable it by writing

`forte = { version = "1.0.0-alpha.4", default-features = false }`